### PR TITLE
docs: remove the Community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,6 @@ joined := (
 
 ![](media/repl_example.gif)
 
-### Community
-
-You can join the [Preludio community on Discord](https://discord.gg/FHJnhGyK).
-
 ### Data Types
 
 The language supports the following data types:


### PR DESCRIPTION
Removes the Community section (the Discord invite) from the README, as requested ahead of the 0.4.0 release.

Four lines, docs only — no other reference to it remains in the README.

Needed as a PR because `main` requires a review; once it is merged I will tag `0.4.0` and publish the release.